### PR TITLE
Use mocks in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/Giftbi
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. To run the tests, you'll need to set up a few environment variables (using a `.env` file in the root directory works well): 
-
-- `LIGHTRAIL_API_KEY` : your Lightrail API key (make sure to use your **test mode** API key for running tests: they make posts to the live API).
-- `STRIPE_API_KEY` : your Stripe API key (make sure to use your **test data** here as well)
-- `TEST_CURRENCY` : the currency to use when running the tests.
-- `LIGHTRAIL_TEST_CODE` : the fullcode that the tests will run against. It must have a balance of 500 (ie $5 USD).
-- `LIGHTRAIL_TEST_CARD_ID` : the cardId for the fullcode listed above.
-- `LIGHTRAIL_TEST_TRANSACTION_ID` : a transactionId for any drawdown transaction on the Lightrail code/card you're using for testing.
-
-Then, run `bundle exec rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies, then run `bundle exec rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/lib/lightrail_stripe.rb
+++ b/lib/lightrail_stripe.rb
@@ -1,4 +1,3 @@
-require "dotenv/load"
 require "faraday"
 require "openssl"
 require "json"

--- a/lightrail_stripe.gemspec
+++ b/lightrail_stripe.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug", "~>3.4"
 
   spec.add_runtime_dependency "stripe", "~>3.0"
-  spec.add_runtime_dependency "dotenv", "~>2.2"
   spec.add_runtime_dependency "faraday", "~>0.12"
   spec.add_runtime_dependency "json", "~>1.7"
   spec.add_runtime_dependency "openssl", "~>2.0"

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -3,6 +3,67 @@ require "spec_helper"
 RSpec.describe Lightrail::Connection do
   subject(:connection) {Lightrail::Connection}
 
+  let(:example_code) {'this-is-a-code'}
+  let(:example_card_id) {'this-is-a-card-id'}
+  let(:example_transaction_id) {'this-is-a-transaction-id'}
+  let(:example_request_body) {{
+      value: -1,
+      userSuppliedId: '123456-abcdef'
+  }}
+
+
+  describe ".ping" do
+    it "GETs the ping endpoint" do
+      expect(connection).to receive(:make_get_request_and_parse_response).with(/ping/).and_return(true)
+      connection.ping
+    end
+  end
+
+  describe ".get_code_balance" do
+    it "GETs the balance endpoint for the provided code" do
+      expect(connection).to receive(:make_get_request_and_parse_response).with(/codes\/#{example_code}\/balance/).and_return(true)
+      connection.get_code_balance(example_code)
+    end
+  end
+
+  describe ".get_card_id_balance" do
+    it "GETs the balance endpoint for the provided cardId" do
+      expect(connection).to receive(:make_get_request_and_parse_response).with(/cards\/#{example_card_id}\/balance/).and_return(true)
+      connection.get_card_id_balance(example_card_id)
+    end
+  end
+
+  describe ".make_code_transaction" do
+    it "POSTs to the transaction endpoint for the provided code with the provided request body" do
+      expect(connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions/, example_request_body).and_return(true)
+      connection.make_code_transaction(example_code, example_request_body)
+    end
+  end
+
+  describe ".make_card_id_transaction" do
+    it "POSTs to the transaction endpoint for the provided cardId with the provided request body" do
+      expect(connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions/, example_request_body).and_return(true)
+      connection.make_card_id_transaction(example_card_id, example_request_body)
+    end
+  end
+
+  describe ".handle_pending" do
+    it "POSTs the action and request body to the transaction endpoint for the provided cardId & transactionId" do
+      action = 'void'
+      expect(connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions\/#{example_transaction_id}\/#{action}/, example_request_body).and_return(true)
+      connection.handle_pending(example_card_id, example_transaction_id, action, example_request_body)
+    end
+  end
+
+  describe ".post_refund" do
+    it "POSTs to the refund endpoint for the provided cardId & transactionId" do
+      expect(connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions\/#{example_transaction_id}\/refund/, example_request_body).and_return(true)
+      connection.post_refund(example_card_id, example_transaction_id, example_request_body)
+    end
+  end
+
+
+
   describe ".connection" do
     let(:conn) {Lightrail::Connection.connection}
 

--- a/spec/lightrail_charge_spec.rb
+++ b/spec/lightrail_charge_spec.rb
@@ -3,27 +3,55 @@ require "spec_helper"
 RSpec.describe Lightrail::LightrailCharge do
   subject(:lightrail_charge) {Lightrail::LightrailCharge}
 
+  let(:lightrail_connection) {Lightrail::Connection}
+
+  let(:example_code) {'this-is-a-code'}
+
+  let(:example_card_id) {'this-is-a-card-id'}
+
   let(:code_charge_params) {{
       amount: 1,
       currency: 'USD',
-      code: ENV['LIGHTRAIL_TEST_CODE'],
+      code: example_code,
   }}
 
   let(:card_id_charge_params) {{
       amount: 1,
       currency: 'USD',
-      cardId: ENV['LIGHTRAIL_TEST_CARD_ID'],
+      cardId: example_card_id,
   }}
 
-  let(:pending_code_charge_params) {{
-      amount: 1,
+  let(:translated_code_charge_params) {
+    Lightrail::Translator.translate_charge_params(code_charge_params)
+  }
+
+  let(:pending_charge_object_details) {{
+      cardId: 'card-123456',
+      codeLastFour: 'TEST',
       currency: 'USD',
-      code: ENV['LIGHTRAIL_TEST_CODE'],
-      capture: false,
+      transactionId: 'transaction-123456',
+      transactionType: 'PENDING_CREATE',
+      userSuppliedId: '123-abc-456-def',
+      value: -1,
   }}
+
+  let(:faraday_code_charge_response) {
+    Faraday::Response.new(
+        status: 200,
+        body: "{\"transaction\":{\"transactionId\":\"transaction-abc123\",\"value\":-1,\"userSuppliedId\":\"d9daba61\",\"dateCreated\":\"2017-08-25T17:24:55.767Z\",\"transactionType\":\"DRAWDOWN\",\"transactionAccessMethod\":\"RAWCODE\",\"giftbitUserId\":\"user-123456-TEST\",\"cardId\":\"card-12345\",\"currency\":\"USD\",\"codeLastFour\":\"QRST\"}}")
+  }
+
+  let(:faraday_card_id_charge_response) {
+    Faraday::Response.new(
+        status: 200,
+        body: "{\"transaction\":{\"transactionId\":\"transaction-abc123\",\"value\":-1,\"userSuppliedId\":\"c7675b6c\",\"dateCreated\":\"2017-08-25T17:28:17.044Z\",\"transactionType\":\"DRAWDOWN\",\"transactionAccessMethod\":\"CARDID\",\"giftbitUserId\":\"user-123456-TEST\",\"cardId\":\"card-12345\",\"currency\":\"USD\",\"codeLastFour\":\"QRST\"}}")
+  }
+
 
   describe ".new" do
     it "creates a new charge object from valid API response" do
+      allow(lightrail_connection).to receive_message_chain(:connection, :post).and_return(faraday_code_charge_response)
+
       charge_response = lightrail_charge.create(code_charge_params)
       expect(charge_response).to be_a(lightrail_charge)
     end
@@ -32,49 +60,48 @@ RSpec.describe Lightrail::LightrailCharge do
   describe ".create" do
     context "when given valid params" do
       it "creates a drawdown code transaction with minimum required params" do
-        charge_response = lightrail_charge.create(code_charge_params)
-        expect(charge_response).to be_a(lightrail_charge)
-        expect(charge_response.transactionType).to eq('DRAWDOWN')
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{code_charge_params[:code]}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+
+        lightrail_charge.create(code_charge_params)
       end
 
       it "creates a drawdown card transaction with minimum required params" do
-        card_id_charge_params
-        charge_response = lightrail_charge.create(card_id_charge_params)
-        expect(charge_response).to be_a(lightrail_charge)
-        expect(charge_response.transactionType).to eq('DRAWDOWN')
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{card_id_charge_params[:cardId]}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+
+        lightrail_charge.create(card_id_charge_params)
       end
 
       it "uses userSuppliedId if supplied in param hash" do
         code_charge_params[:userSuppliedId] ='test-charge-' + rand().to_s
-        charge_response = lightrail_charge.create(code_charge_params)
-        expect(charge_response.userSuppliedId).to eq(code_charge_params[:userSuppliedId])
+
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes/, hash_including(userSuppliedId: code_charge_params[:userSuppliedId])).and_return({"transaction" => {}})
+
+        lightrail_charge.create(code_charge_params)
       end
 
       it "uses 'value' instead of 'amount' if supplied in param hash" do
         code_charge_params[:value] = -2
-        code_charge_params[:userSuppliedId] = 'test-charge-' + rand().to_s
-        charge_response = lightrail_charge.create(code_charge_params)
-        expect(charge_response.value).to eq(code_charge_params[:value])
+
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(String, hash_including(value: -2)).and_return({"transaction" => {}})
+
+        lightrail_charge.create(code_charge_params)
       end
 
-      it "creates a pending transaction when 'capture=false'" do
+      it "set 'pending=true' when 'capture=false' in params" do
         code_charge_params[:capture] = false
-        charge_response = lightrail_charge.create(code_charge_params)
-        expect(charge_response.transactionType).to eq('PENDING_CREATE')
-      end
 
-      it "creates a pending transaction when 'pending=true'" do
-        code_charge_params[:pending] = true
-        charge_response = lightrail_charge.create(code_charge_params)
-        expect(charge_response.transactionType).to eq('PENDING_CREATE')
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(String, hash_including(pending: true)).and_return({"transaction" => {}})
+
+        lightrail_charge.create(code_charge_params)
       end
 
       context "when an error response comes back from the API anyway" do
         it "should produce a meaningful error" do
-          code_charge_params[:metadata] = {
-              giftbit_exception_action: 'transaction:create'
-          }
-          expect {lightrail_charge.create(code_charge_params)}.to raise_error(Lightrail::LightrailError, /Server responded with/), "expected a LightrailError with message 'Server responded with:'"
+          bad_faraday_response = Faraday::Response.new(status: 404, body: "{\"status\":404,\"message\":\"Could not find object\"}")
+
+          allow(lightrail_connection).to receive_message_chain(:connection, :post).and_return(bad_faraday_response)
+
+          expect {lightrail_charge.create(code_charge_params)}.to raise_error(Lightrail::LightrailError, /Could not find object/)
         end
       end
     end
@@ -83,7 +110,7 @@ RSpec.describe Lightrail::LightrailCharge do
       it "throws an error when required params are missing" do
         expect {lightrail_charge.create()}.to raise_error(ArgumentError), "called LightrailCharge.create with no params"
         expect {lightrail_charge.create({})}.to raise_error(Lightrail::LightrailArgumentError), "called LightrailCharge.create with empty object"
-        expect {lightrail_charge.create({code: ENV['LIGHTRAIL_TEST_CODE']})}.to raise_error(Lightrail::LightrailArgumentError), "called LightrailCharge.create with '{code: ENV['LIGHTRAIL_TEST_CODE']}'"
+        expect {lightrail_charge.create({code: example_code})}.to raise_error(Lightrail::LightrailArgumentError), "called LightrailCharge.create with '{code: example_code}'"
         expect {lightrail_charge.create([])}.to raise_error(Lightrail::LightrailArgumentError), "called LightrailCharge.create with empty array"
       end
     end
@@ -92,13 +119,16 @@ RSpec.describe Lightrail::LightrailCharge do
 
   describe "#cancel" do
     before(:each) do
-      @pending_to_void = lightrail_charge.create(pending_code_charge_params)
+      @pending_to_void = lightrail_charge.new(pending_charge_object_details)
     end
 
     context "called on a valid pending transaction" do
       it "voids a pending transaction" do
-        voiding_response = @pending_to_void.cancel!
-        expect(voiding_response.transactionType).to eq('PENDING_VOID')
+        expect(lightrail_connection).
+            to receive(:make_post_request_and_parse_response).
+                with(/cards\/#{@pending_to_void.cardId}\/transactions\/#{@pending_to_void.transactionId}\/void/, Hash).
+                and_return({"transaction" => {}})
+        @pending_to_void.cancel!
       end
     end
 
@@ -107,23 +137,21 @@ RSpec.describe Lightrail::LightrailCharge do
         @pending_to_void.remove_instance_variable(:@transactionId)
         expect {@pending_to_void.cancel!}.to raise_error(Lightrail::LightrailArgumentError)
       end
-
-      it "throw an error when the transaction has already been captured (not voided)" do
-        @pending_to_void.capture!
-        expect {@pending_to_void.cancel!}.to raise_error(Lightrail::LightrailError)
-      end
     end
   end
 
   describe "#capture" do
     before(:each) do
-      @pending_to_capture = lightrail_charge.create(pending_code_charge_params)
+      @pending_to_capture = lightrail_charge.new(pending_charge_object_details)
     end
 
     context "called on a valid pending transaction" do
       it "captures a pending transaction" do
-        capture_response = @pending_to_capture.capture!
-        expect(capture_response.transactionType).to eq('DRAWDOWN')
+        expect(lightrail_connection).
+            to receive(:make_post_request_and_parse_response).
+                with(/cards\/#{@pending_to_capture.cardId}\/transactions\/#{@pending_to_capture.transactionId}\/capture/, Hash).
+                and_return({"transaction" => {}})
+        @pending_to_capture.capture!
       end
     end
 
@@ -131,11 +159,6 @@ RSpec.describe Lightrail::LightrailCharge do
       it "throws an error when required vars are missing or in the wrong format" do
         @pending_to_capture.remove_instance_variable(:@transactionId)
         expect {@pending_to_capture.capture!}.to raise_error(Lightrail::LightrailArgumentError)
-      end
-
-      it "throw an error when the transaction has already been voided (not captured)" do
-        @pending_to_capture.cancel!
-        expect {@pending_to_capture.capture!}.to raise_error(Lightrail::LightrailError)
       end
     end
   end

--- a/spec/lightrail_fund_spec.rb
+++ b/spec/lightrail_fund_spec.rb
@@ -3,23 +3,27 @@ require "spec_helper"
 RSpec.describe Lightrail::LightrailFund do
   subject(:lightrail_fund) {Lightrail::LightrailFund}
 
+  let(:lightrail_connection) {Lightrail::Connection}
+
   let(:fund_params) {{
       amount: 1,
       currency: 'USD',
-      cardId: ENV['LIGHTRAIL_TEST_CARD_ID'],
+      cardId: 'this-is-a-card-id',
+      userSuppliedId: '123-abc-456-def',
   }}
 
   describe ".create" do
     context "when given valid params" do
+      before(:each) do
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{fund_params[:cardId]}\/transactions/, hash_including({userSuppliedId: fund_params[:userSuppliedId]})).and_return({"transaction" => {}})
+      end
+
       it "funds a gift card with minimum required params" do
-        fund_response = lightrail_fund.create(fund_params)
-        expect(fund_response.transactionType).to eq('FUND'), "called LightrailFund.create with #{fund_params.inspect}, got back #{fund_response.inspect}"
+        lightrail_fund.create(fund_params)
       end
 
       it "uses userSuppliedId if supplied in param hash" do
-        fund_params[:userSuppliedId] = 'test-fund-' + rand().to_s
-        fund_response = lightrail_fund.create(fund_params)
-        expect(fund_response.userSuppliedId).to eq(fund_params[:userSuppliedId]), "called LightrailFund.create with #{fund_params.inspect}, got back #{fund_response.inspect}"
+        lightrail_fund.create(fund_params)
       end
     end
 

--- a/spec/lightrail_stripe_spec.rb
+++ b/spec/lightrail_stripe_spec.rb
@@ -8,9 +8,4 @@ RSpec.describe Lightrail do
   it "stores the base URL for the Lightrail API" do
     expect(Lightrail.api_base).to eq('https://dev.lightrail.com/v1').or(eq('https://api.lightrail.com/v1'))
   end
-
-  it "stores a string for the API key" do
-    expect(Lightrail.api_key).to match(/[A-Z0-9]+/)
-  end
-
 end

--- a/spec/ping_spec.rb
+++ b/spec/ping_spec.rb
@@ -3,8 +3,16 @@ require "spec_helper"
 RSpec.describe Lightrail::Ping do
   subject(:ping) {Lightrail::Ping}
 
+  let(:faraday_ping_response) {
+    Faraday::Response.new(
+        status: 200,
+        body: "{\"user\":{\"username\":\"happy_user@example.com\",\"mode\":\"TEST\",\"scopes\":[]}}")
+  }
+
   describe ".ping" do
     it "pings" do
+      allow(Lightrail::Connection).to receive_message_chain(:connection, :get).and_return(faraday_ping_response)
+
       ping_response = ping.ping
       expect(ping_response).to be_a(ping)
     end

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -3,20 +3,30 @@ require "spec_helper"
 RSpec.describe Lightrail::Refund do
   subject(:refund) {Lightrail::Refund}
 
+  let(:lightrail_connection) {Lightrail::Connection}
+
+  let(:charge_object_details) {{
+      cardId: 'card-123456',
+      codeLastFour: 'TEST',
+      currency: 'USD',
+      transactionId: 'transaction-123456',
+      transactionType: 'DRAWDOWN',
+      userSuppliedId: '123-abc-456-def',
+      value: -1,
+  }}
+
   describe ".create" do
 
     context "when given valid params" do
       it "refunds a transaction" do
-        charge_params = {
-            amount: 1,
-            currency: 'USD',
-            code: ENV['LIGHTRAIL_TEST_CODE'],
-            capture: true,
-        }
-        charge = Lightrail::LightrailCharge.create(charge_params)
-        refund_response = refund.create(charge)
-        expect(refund_response.transactionType).to eq('DRAWDOWN_REFUND')
-        expect(refund_response.parentTransactionId).to eq(charge.transactionId)
+        charge = Lightrail::LightrailCharge.new(charge_object_details)
+
+        expect(lightrail_connection).
+            to receive(:make_post_request_and_parse_response).
+                with(/cards\/#{charge.cardId}\/transactions\/#{charge.transactionId}\/refund/, Hash).
+                and_return({"transaction" => {}})
+
+        refund.create(charge)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,49 +12,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  config.before(:suite) do
-    Lightrail.api_key = ENV['LIGHTRAIL_API_KEY']
-  end
-
-  # Ensure card balance will go back to same state after test suite runs
-  config.before(:suite) do
-    balance_response = Lightrail::LightrailValue.retrieve_by_code(ENV['LIGHTRAIL_TEST_CODE'])
-    if (balance_response.is_a? Lightrail::LightrailValue)
-      $LIGHTRAIL_CARD_BALANCE_BEFORE_TESTS = balance_response.principal['currentValue']
-    else
-      fail "balance_response was not an instance of Lightrail::LightrailValue"
-    end
-    puts "Card balance before tests: #{$LIGHTRAIL_CARD_BALANCE_BEFORE_TESTS}"
-  end
-
-  config.after(:suite) do
-    balance_response = Lightrail::LightrailValue.retrieve_by_code(ENV['LIGHTRAIL_TEST_CODE'])
-    if (balance_response.is_a? Lightrail::LightrailValue)
-      balance_after_tests = balance_response.principal['currentValue']
-    else
-      fail "balance_response was not an instance of Lightrail::LightrailValue"
-    end
-
-    difference = $LIGHTRAIL_CARD_BALANCE_BEFORE_TESTS - balance_after_tests
-
-    if difference != 0
-      fund_object_to_restore_balance = {
-          cardId: ENV['LIGHTRAIL_TEST_CARD_ID'],
-          amount: difference,
-          currency: ENV['TEST_CURRENCY'],
-          userSuppliedId: 'restoring-balance-after-tests-' + SecureRandom::uuid
-      }
-
-      Lightrail::LightrailFund.create(fund_object_to_restore_balance)
-
-      confirmation_new_balance = Lightrail::LightrailValue.retrieve_by_code(ENV['LIGHTRAIL_TEST_CODE']).principal['currentValue']
-      puts "Card balance restored after tests: #{confirmation_new_balance}"
-    else
-      puts "Card balance not changed by tests: #{balance_after_tests}"
-    end
-
-    $LIGHTRAIL_CARD_BALANCE_BEFORE_TESTS = nil
-  end
-
 end

--- a/spec/stripe_lightrail_hybrid_charge_spec.rb
+++ b/spec/stripe_lightrail_hybrid_charge_spec.rb
@@ -3,12 +3,47 @@ require "spec_helper"
 RSpec.describe Lightrail::StripeLightrailHybridCharge do
   subject(:hybrid_charge) {Lightrail::StripeLightrailHybridCharge}
 
+  let(:lightrail_connection) {Lightrail::Connection}
+  let(:lightrail_value) {Lightrail::LightrailValue}
+  let(:lightrail_charge) {Lightrail::LightrailCharge}
+  let(:stripe_charge) {Stripe::Charge}
+
+  let(:example_code) {'this-is-a-code'}
+  let(:example_card_id) {'this-is-a-card-id'}
+  let(:example_pending_transaction_id) {'transaction-pending-123456'}
+  let(:example_captured_transaction_id) {'transaction-captured-123456'}
+
   let(:charge_params) {{
       amount: 1000,
       currency: 'USD',
-      code: ENV['LIGHTRAIL_TEST_CODE'],
+      code: example_code,
       source: 'tok_mastercard',
   }}
+
+  let (:lightrail_charge_instance) {instance_double(lightrail_charge)}
+
+  let(:lightrail_captured_transaction) {lightrail_charge.new(
+      {
+          cardId: example_card_id,
+          codeLastFour: 'TEST',
+          currency: 'USD',
+          transactionId: example_captured_transaction_id,
+          transactionType: 'DRADOWN',
+          userSuppliedId: '123-abc-456-def',
+          value: -500,
+      }
+  )}
+
+  let(:lightrail_value_object) {lightrail_value.new(
+      {principal: {"currentValue" => 400, "state" => "ACTIVE", "programId" => "program-123456", "valueStoreId" => "value-123456"},
+       attached: [{"currentValue" => 50, "state" => "ACTIVE", "programId" => "program-789", "valueStoreId" => "value-2468"}]}
+  )}
+
+  let(:stripe_charge_object) {
+    charge = stripe_charge.new({:id => 'mock-stripe-charge'})
+    charge.amount = 450
+    charge
+  }
 
 
   before do
@@ -18,48 +53,72 @@ RSpec.describe Lightrail::StripeLightrailHybridCharge do
   describe ".create" do
     context "when given valid params" do
       it "charges the appropriate amounts to Stripe and Lightrail with minimum required params" do
-        # TODO: improve translator (https://trello.com/c/7v69y2YS/38-improve-translator)
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        Lightrail::Refund.create(hybrid_charge_response.lightrail_charge)
-        expect(hybrid_charge_response).to be_a(hybrid_charge)
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+
+        expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
+        expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
+        expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
+
+        hybrid_charge.create(charge_params)
       end
 
       it "adds the Stripe transaction ID to Lightrail metadata" do
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        Lightrail::Refund.create(hybrid_charge_response.lightrail_charge)
-        expect(hybrid_charge_response.lightrail_charge.metadata['hybridChargeDetails']['stripeTransactionId']).to eq(hybrid_charge_response.stripe_charge.id)
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+        allow(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
+        allow(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
+
+        expect(lightrail_charge_instance).to receive(:capture!).with(hash_including(:metadata => hash_including(:hybridChargeDetails))).and_return(lightrail_captured_transaction)
+
+        hybrid_charge.create(charge_params)
       end
 
       it "adjusts the LR share to respect Stripe's minimum charge amount when necessary" do
-        charge_params[:amount] = 510
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        Lightrail::Refund.create(hybrid_charge_response.lightrail_charge)
-        expect(hybrid_charge_response.lightrail_charge.value).to eq(-460)
+        charge_params[:amount] = 460
+        stripe_charge_object.amount = 50
+
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+        allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
+
+        expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -410})).and_return(lightrail_charge_instance)
+        expect(stripe_charge).to receive(:create).with(hash_including({amount: 50})).and_return(stripe_charge_object)
+
+        hybrid_charge.create(charge_params)
       end
 
       it "charges Lightrail only, when card balance is sufficient" do
         charge_params[:amount] = 1
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        expect(hybrid_charge_response).to be_a(hybrid_charge)
-        expect(hybrid_charge_response.lightrail_charge).to be_a(Lightrail::LightrailCharge)
-        expect(hybrid_charge_response.stripe_charge).to be(nil)
+
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+        allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
+
+        expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
+        expect(stripe_charge).not_to receive(:create)
+
+        hybrid_charge.create(charge_params)
       end
 
       it "charges Lightrail only, when no Stripe params given" do
         charge_params[:amount] = 1
         charge_params.delete(:source)
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        expect(hybrid_charge_response).to be_a(hybrid_charge)
-        expect(hybrid_charge_response.lightrail_charge).to be_a(Lightrail::LightrailCharge)
-        expect(hybrid_charge_response.stripe_charge).to be(nil)
+
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+        allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
+
+        expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
+        expect(stripe_charge).not_to receive(:create)
+
+        hybrid_charge.create(charge_params)
       end
 
       it "charges Stripe only, when no Lightrail params given" do
         charge_params.delete(:code)
-        hybrid_charge_response = hybrid_charge.create(charge_params)
-        expect(hybrid_charge_response).to be_a(hybrid_charge)
-        expect(hybrid_charge_response.stripe_charge).to be_a(Stripe::Charge)
-        expect(hybrid_charge_response.lightrail_charge).to be(nil)
+
+        expect(lightrail_value).not_to receive(:retrieve_by_code || :retrieve_by_card_id)
+        expect(lightrail_charge).not_to receive(:create)
+        expect(stripe_charge).to receive(:create).and_return(stripe_charge_object)
+
+
+        hybrid_charge.create(charge_params)
       end
 
     end


### PR DESCRIPTION
Instead of hitting the production API server in the test suite, stub out responses from the API. This means that the suite also no longer requires a test code, cardId, API key, etc to run. Readme.md updated accordingly.