### PR TITLE
Set split tender amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The Stripe parameter could be:
 - `source`, indicating a Stripe token, or
 - `customer`, indicating a Stripe customer ID
 
+You must also pass in the amount to charge to Stripe and the amount to charge to Lightrail. 
+
 Here is a simple example:
 
 ```ruby
@@ -56,13 +58,15 @@ split_tender_charge_params = {
   code: '<GIFT CODE>',
   source: '<STRIPE TOKEN>',
 }
+stripe_amount = 550
+lightrail_amount = 450
 
-split_tender_charge = LightrailClient::StripeLightrailSplitTenderCharge.create(split_tender_charge_params);
+split_tender_charge = Lightrail::StripeLightrailSplitTenderCharge.create(split_tender_charge_params, stripe_amount, lightrail_amount);
 ```
 
-If you don't pass any Lightrail parameters, the entire transaction will be charged to Stripe. Similarly, if you don't provide any Stripe parameters, the library will attempt to charge the entire transaction to Lightrail. If the value of the gift card is not enough to cover the entire transaction amount and no Stripe payment method is included, you will receive a `BadParameterError` asking you to provide a Stripe parameter.
+If you don't provide any Lightrail payment parameters and set the `lightrail_amount` to 0, the entire transaction will be charged to Stripe. Similarly, if you don't provide any Stripe payment parameters and set the `stripe_amount` to 0, the library will attempt to charge the entire transaction to Lightrail. If the value of the gift card is not enough to cover the entire transaction amount and no Stripe payment method is included, you will receive a `BadParameterError` asking you to provide a Stripe parameter.
 
-When both a Lightrail and a Stripe parameter are provided, the library will try to split the payment, in such a way that Lightrail contributes to the payment as much as possible. This usually means:
+There is also a wrapper method that can determine the Stripe/Lightrail split automatically: `Lightrail::StripeLightrailSplitTenderCharge.create_with_automatic_split`. This method accepts the same `charge_params` as the default `.create`, but does not expect a `stripe_amount` or `lightrail_amount`. When both a Lightrail and a Stripe payment method are provided to this method, the library will try to split the payment in such a way that Lightrail contributes to the payment as much as possible. This usually means:
 
 - If the Lightrail value is sufficient, the entire transaction will be charged to the gift card.
 - If the transaction amount is larger than the Lightrail value, the remainder will be charged to Stripe.

--- a/lib/lightrail_stripe/version.rb
+++ b/lib/lightrail_stripe/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/stripe_lightrail_split_tender_charge_spec.rb
+++ b/spec/stripe_lightrail_split_tender_charge_spec.rb
@@ -53,49 +53,43 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
   end
 
   describe ".create" do
-    context "when given valid params" do
+    context "when given valid parameters" do
       it "charges the appropriate amounts to Stripe and Lightrail code" do
-        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
-
         expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 550, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail cardId" do
         charge_params.delete(:code)
         charge_params[:card_id] = example_card_id
 
-        allow(lightrail_value).to receive(:retrieve_by_card_id).with(example_card_id).and_return(lightrail_value_object)
-
         expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 550, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail contactId" do
         charge_params.delete(:code)
         charge_params[:contact_id] = example_contact_id
 
-        allow(lightrail_value).to receive(:retrieve_by_card_id).with(example_card_id).and_return(lightrail_value_object)
         allow(Lightrail::Contact).to receive(:get_account_card_id_by_contact_id).with(example_contact_id, 'USD').and_return(example_card_id)
 
         expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 550, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail shopperId" do
         charge_params.delete(:code)
         charge_params[:shopper_id] = example_shopper_id
 
-        allow(lightrail_value).to receive(:retrieve_by_card_id).with(example_card_id).and_return(lightrail_value_object)
         allow(Lightrail::Contact).to receive(:get_contact_id_from_id_or_shopper_id).with(hash_including({shopper_id: example_shopper_id})).and_return(example_contact_id)
         allow(Lightrail::Contact).to receive(:get_account_card_id_by_contact_id).with(example_contact_id, 'USD').and_return(example_card_id)
 
@@ -103,55 +97,51 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 550, 450)
       end
 
       it "adds the Stripe transaction ID to Lightrail metadata" do
-        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
         allow(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
         allow(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
 
         expect(lightrail_charge_instance).to receive(:capture!).with(hash_including(:metadata => hash_including(:splitTenderChargeDetails))).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 550, 450)
       end
 
       it "adjusts the LR share to respect Stripe's minimum charge amount when necessary" do
         charge_params[:amount] = 460
         stripe_charge_object.amount = 50
 
-        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
         allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
         expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -410})).and_return(lightrail_charge_instance)
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 50})).and_return(stripe_charge_object)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 50, 410)
       end
 
       it "charges Lightrail only, when card balance is sufficient" do
         charge_params[:amount] = 1
 
-        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
         allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
         expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
         expect(stripe_charge).not_to receive(:create)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 0, 1)
       end
 
       it "charges Lightrail only, when no Stripe params given" do
         charge_params[:amount] = 1
         charge_params.delete(:source)
 
-        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
         allow(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
         expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
         expect(stripe_charge).not_to receive(:create)
 
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 0, 1)
       end
 
       it "charges Stripe only, when no Lightrail params given" do
@@ -161,20 +151,30 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(lightrail_charge).not_to receive(:create)
         expect(stripe_charge).to receive(:create).and_return(stripe_charge_object)
 
-
-        split_tender_charge.create(charge_params)
+        split_tender_charge.create(charge_params, 1000, 0)
       end
-
     end
 
     context "when given bad/missing params" do
       it "throws an error when missing both Stripe and Lightrail payment options" do
         charge_params.delete(:code)
         charge_params.delete(:source)
-        expect {split_tender_charge.create(charge_params)}.to raise_error(Lightrail::LightrailArgumentError)
+        expect {split_tender_charge.create(charge_params, 0, 0)}.to raise_error(Lightrail::LightrailArgumentError)
       end
     end
-
   end
 
+  describe ".create_with_automatic_split" do
+    context "when given valid params" do
+      it "passes the Stripe and Lightrail amounts to .create" do
+        allow(lightrail_value).to receive(:retrieve_by_code).with(example_code).and_return(lightrail_value_object)
+
+        expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -450})).and_return(lightrail_charge_instance)
+        expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
+        expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
+
+        split_tender_charge.create_with_automatic_split(charge_params)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of automatically calculating the Stripe and Lightrail shares from the total transaction amount and charging as much as possible to Lightrail by default, require the share amounts to be passed in to the default method for creating a split tender charge. 