### PR TITLE
Split tender takes lightrail amount only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Before using any parts of the library, you need to set up your Lightrail API key
 
 ```ruby
 Lightrail.api_key = '<your lightrail API key>'
-Stripe.api_key = '<your stripe API key>
+Stripe.api_key = '<your stripe API key>'
 ```
 
 *A note on sample code snippets: for reasons of legibility, the output for most calls has been simplified. Attributes of response objects that are not relevant here have been omitted.*
@@ -47,7 +47,7 @@ The Stripe parameter could be:
 - `source`, indicating a Stripe token, or
 - `customer`, indicating a Stripe customer ID
 
-You must also pass in the amount to charge to Stripe and the amount to charge to Lightrail. 
+You must also pass in the amount to charge to Lightrail. 
 
 Here is a simple example:
 
@@ -58,13 +58,12 @@ split_tender_charge_params = {
   code: '<GIFT CODE>',
   source: '<STRIPE TOKEN>',
 }
-stripe_amount = 550
 lightrail_amount = 450
 
-split_tender_charge = Lightrail::StripeLightrailSplitTenderCharge.create(split_tender_charge_params, stripe_amount, lightrail_amount);
+split_tender_charge = Lightrail::StripeLightrailSplitTenderCharge.create(split_tender_charge_params, lightrail_amount)
 ```
 
-If you don't provide any Lightrail payment parameters and set the `lightrail_amount` to 0, the entire transaction will be charged to Stripe. Similarly, if you don't provide any Stripe payment parameters and set the `stripe_amount` to 0, the library will attempt to charge the entire transaction to Lightrail. If the value of the gift card is not enough to cover the entire transaction amount and no Stripe payment method is included, you will receive a `BadParameterError` asking you to provide a Stripe parameter.
+If you don't provide any Lightrail payment parameters and set the `lightrail_amount` to 0, the entire transaction will be charged to Stripe. Similarly, if you don't provide any Stripe payment parameters and set the `lightrail_amount` to the full amount, the library will attempt to charge the entire transaction to Lightrail. If the value of the gift card is not enough to cover the entire transaction amount and no Stripe payment method is included, you will receive a `BadParameterError` asking you to provide a Stripe parameter.
 
 There is also a wrapper method that can determine the Stripe/Lightrail split automatically: `Lightrail::StripeLightrailSplitTenderCharge.create_with_automatic_split`. This method accepts the same `charge_params` as the default `.create`, but does not expect a `stripe_amount` or `lightrail_amount`. When both a Lightrail and a Stripe payment method are provided to this method, the library will try to split the payment in such a way that Lightrail contributes to the payment as much as possible. This usually means:
 

--- a/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
+++ b/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
@@ -2,16 +2,14 @@ module Lightrail
   class StripeLightrailSplitTenderCharge < Lightrail::LightrailObject
     attr_accessor :lightrail_charge, :stripe_charge, :payment_summary
 
-    def self.create (charge_params, stripe_share, lr_share)
+    def self.create (charge_params, lr_share)
       # Convert to Translator.translate_split_tender_charge_params!()
       Lightrail::SplitTenderValidator.validate_split_tender_charge_params!(charge_params)
 
       total_amount = charge_params[:amount]
       currency = charge_params[:currency]
 
-      if total_amount != stripe_share + lr_share
-        raise Lightrail::LightrailArgumentError.new("Transaction amount does not match the sum of the given Stripe and Lightrail shares.")
-      end
+      stripe_share = total_amount - lr_share
 
       if lr_share > 0 # start with lightrail charge first
         lightrail_charge_params = Lightrail::Translator.construct_pending_charge_params_from_split_tender(charge_params, lr_share)
@@ -53,9 +51,7 @@ module Lightrail
 
       split_amounts = self.determine_split!(charge_params)
       lr_share = split_amounts[:lightrail_amount]
-      stripe_share = split_amounts[:stripe_amount]
-
-      self.create(charge_params, stripe_share, lr_share)
+      self.create(charge_params, lr_share)
     end
 
 

--- a/lib/lightrail_stripe/version.rb
+++ b/lib/lightrail_stripe/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/lib/lightrail_stripe/version.rb
+++ b/lib/lightrail_stripe/version.rb
@@ -1,3 +1,3 @@
-module Lightrail
+module LightrailStripe
   VERSION = "0.5.0"
 end

--- a/lightrail_stripe.gemspec
+++ b/lightrail_stripe.gemspec
@@ -5,11 +5,11 @@ require "lightrail_stripe/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "lightrail_stripe"
-  spec.version       = Lightrail::VERSION
+  spec.version       = LightrailStripe::VERSION
   spec.authors       = ["Lightrail"]
   spec.email         = ["tana.j@lightrail.com"]
 
-  spec.summary       = "A client library for the Lightrail API"
+  spec.summary       = "A gem for creating Lightrail-Stripe integrated applications"
   spec.description   = "Acquire and retain customers using account credits, gift cards, promotions, and points."
   spec.homepage      = "https://www.lightrail.com/"
   spec.license       = "MIT"

--- a/lightrail_stripe.gemspec
+++ b/lightrail_stripe.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Lightrail"]
   spec.email         = ["tana.j@lightrail.com"]
 
-  spec.summary       = "A gem for creating Lightrail-Stripe integrated applications"
+  spec.summary       = "A integration gem to use Stripe and Lightrail for payment processing"
   spec.description   = "Acquire and retain customers using account credits, gift cards, promotions, and points."
   spec.homepage      = "https://www.lightrail.com/"
   spec.license       = "MIT"

--- a/spec/stripe_lightrail_split_tender_charge_spec.rb
+++ b/spec/stripe_lightrail_split_tender_charge_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params, 550, 450)
+        split_tender_charge.create(charge_params, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail cardId" do
@@ -72,7 +72,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params, 550, 450)
+        split_tender_charge.create(charge_params, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail contactId" do
@@ -85,7 +85,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params, 550, 450)
+        split_tender_charge.create(charge_params, 450)
       end
 
       it "charges the appropriate amounts to Stripe and Lightrail shopperId" do
@@ -99,7 +99,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 550})).and_return(stripe_charge_object)
         expect(lightrail_charge_instance).to receive(:capture!).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params, 550, 450)
+        split_tender_charge.create(charge_params, 450)
       end
 
       it "adds the Stripe transaction ID to Lightrail metadata" do
@@ -108,7 +108,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
 
         expect(lightrail_charge_instance).to receive(:capture!).with(hash_including(:metadata => hash_including(:splitTenderChargeDetails))).and_return(lightrail_captured_transaction)
 
-        split_tender_charge.create(charge_params, 550, 450)
+        split_tender_charge.create(charge_params, 450)
       end
 
       it "adjusts the LR share to respect Stripe's minimum charge amount when necessary" do
@@ -120,7 +120,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(lightrail_charge).to receive(:create).with(hash_including({pending: true, value: -410})).and_return(lightrail_charge_instance)
         expect(stripe_charge).to receive(:create).with(hash_including({amount: 50})).and_return(stripe_charge_object)
 
-        split_tender_charge.create(charge_params, 50, 410)
+        split_tender_charge.create(charge_params, 410)
       end
 
       it "charges Lightrail only, when card balance is sufficient" do
@@ -131,10 +131,10 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
         expect(stripe_charge).not_to receive(:create)
 
-        split_tender_charge.create(charge_params, 0, 1)
+        split_tender_charge.create(charge_params, 1)
       end
 
-      it "charges Lightrail only, when no Stripe params given" do
+      it "charges Lightrail only, when no Stripe params given and Lightrail card value is sufficient" do
         charge_params[:amount] = 1
         charge_params.delete(:source)
 
@@ -143,17 +143,17 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         expect(lightrail_charge).to receive(:create).with(hash_including({value: -1})).and_return(lightrail_charge_instance)
         expect(stripe_charge).not_to receive(:create)
 
-        split_tender_charge.create(charge_params, 0, 1)
+        split_tender_charge.create(charge_params, 1)
       end
 
-      it "charges Stripe only, when no Lightrail params given" do
+      it "charges Stripe only, when Lightrail amount set to 0" do
         charge_params.delete(:code)
 
         expect(lightrail_value).not_to receive(:retrieve_code_details || :retrieve_card_details)
         expect(lightrail_charge).not_to receive(:create)
         expect(stripe_charge).to receive(:create).and_return(stripe_charge_object)
 
-        split_tender_charge.create(charge_params, 1000, 0)
+        split_tender_charge.create(charge_params, 0)
       end
     end
 
@@ -161,7 +161,7 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
       it "throws an error when missing both Stripe and Lightrail payment options" do
         charge_params.delete(:code)
         charge_params.delete(:source)
-        expect {split_tender_charge.create(charge_params, 0, 0)}.to raise_error(Lightrail::LightrailArgumentError)
+        expect {split_tender_charge.create(charge_params, 0)}.to raise_error(Lightrail::LightrailArgumentError)
       end
     end
   end


### PR DESCRIPTION
- Updates split tender method to take only the Lightrail amount, not the Stripe amount (this was redundant and no longer consistent with other clients)
- Updates readme accordingly, plus a couple typos

- Bugfix: version file was overwriting the Lightrail vanilla client version