### PR TITLE
Don't set 'pending: true' for split tender simulations

### DIFF
--- a/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
+++ b/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
@@ -12,7 +12,7 @@ module Lightrail
       stripe_share = total_amount - lr_share
 
       if lr_share > 0 # start with lightrail charge first
-        lightrail_charge_params = Lightrail::Translator.construct_pending_charge_params_from_split_tender(charge_params, lr_share)
+        lightrail_charge_params = Lightrail::Translator.construct_lightrail_pending_charge_params_from_split_tender(charge_params, lr_share)
 
         lightrail_pending_transaction = Lightrail::LightrailCharge.create(lightrail_charge_params)
 
@@ -62,8 +62,8 @@ module Lightrail
 
       stripe_share = total_amount - lr_share
 
-      if lr_share > 0 # start with lightrail charge first
-        lightrail_charge_params = Lightrail::Translator.construct_pending_charge_params_from_split_tender(charge_params, lr_share)
+      if lr_share > 0 # only need to simulate Lightrail transaction
+        lightrail_charge_params = Lightrail::Translator.construct_lightrail_charge_params_from_split_tender(charge_params, lr_share)
 
         lightrail_simulated_transaction = Lightrail::LightrailCharge.simulate(lightrail_charge_params)
 

--- a/lib/lightrail_stripe/translator.rb
+++ b/lib/lightrail_stripe/translator.rb
@@ -19,10 +19,10 @@ module Lightrail
       self.stripe_params_to_lightrail!(stripe_style_params, false)
     end
 
-    def self.construct_pending_charge_params_from_split_tender(split_tender_charge_params, lr_share)
+    def self.construct_lightrail_charge_params_from_split_tender(split_tender_charge_params, lr_share)
       lightrail_params = split_tender_charge_params.clone
 
-      lightrail_params[:pending] = true
+      lightrail_params[:pending] ||= lightrail_params[:capture] === nil ? false : !lightrail_params.delete(:capture)
       lightrail_params[:value] = -lr_share
       lightrail_params.delete(:amount)
 
@@ -36,6 +36,13 @@ module Lightrail
       lightrail_params[:cardId] ||= Lightrail::Validator.get_card_id(lightrail_params)
 
       lightrail_params[:userSuppliedId] ||= Lightrail::Validator.get_or_create_user_supplied_id(lightrail_params)
+
+      lightrail_params
+    end
+
+    def self.construct_lightrail_pending_charge_params_from_split_tender(split_tender_charge_params, lr_share)
+      lightrail_params = self.construct_lightrail_charge_params_from_split_tender(split_tender_charge_params, lr_share)
+      lightrail_params[:pending] = true
 
       lightrail_params
     end

--- a/lib/lightrail_stripe/version.rb
+++ b/lib/lightrail_stripe/version.rb
@@ -1,3 +1,3 @@
 module LightrailStripe
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
Split tender simulation was including 'pending: true' because of a reused helper method for creating a split tender charge. This caused an nsf error to come back if the card had insufficient funds, even if nsf was set to false.

Fix:
- Refactor method .construct_pending_charge_params_from_split_tender to be a wrapper around a method that sets the charge params with 'pending' set to the reverse of 'capture' if present, otherwise false
- Rename both methods to include 'lightrail' for clarity