### PR TITLE
Refactor split tender validator: check total amount >= lr_share

### DIFF
--- a/lib/lightrail_stripe/split_tender_validator.rb
+++ b/lib/lightrail_stripe/split_tender_validator.rb
@@ -2,16 +2,18 @@ module Lightrail
   class SplitTenderValidator < Lightrail::Validator
 
     def self.validate_split_tender_charge_params! (split_tender_charge_params, lr_share=0)
-      begin
-        return true if ((split_tender_charge_params.is_a? Hash) &&
-            Lightrail::Validator.validate_amount!(split_tender_charge_params[:amount]) &&
-            (split_tender_charge_params[:amount] >= lr_share) &&
-            Lightrail::Validator.validate_currency!(split_tender_charge_params[:currency]) &&
-            (self.has_lightrail_payment_option?(split_tender_charge_params) ||
-                self.has_stripe_payment_option?(split_tender_charge_params)))
-      rescue Lightrail::LightrailArgumentError
-      end
-      raise Lightrail::LightrailArgumentError.new("Invalid split_tender_charge_params: #{split_tender_charge_params.inspect}")
+
+      raise Lightrail::LightrailArgumentError.new("Invalid split_tender_charge_params - must be a hash: #{split_tender_charge_params.inspect}") unless (split_tender_charge_params.is_a? Hash)
+
+      raise Lightrail::LightrailArgumentError.new("Invalid amount in split_tender_charge_params: #{split_tender_charge_params.inspect}") unless Lightrail::Validator.validate_amount!(split_tender_charge_params[:amount])
+
+      raise Lightrail::LightrailArgumentError.new("Amount in split_tender_charge_params less than specified Lightrail share of #{lr_share}: #{split_tender_charge_params.inspect}") unless (split_tender_charge_params[:amount] >= lr_share)
+
+      raise Lightrail::LightrailArgumentError.new("Invalid currency in split_tender_charge_params: #{split_tender_charge_params.inspect}") unless Lightrail::Validator.validate_currency!(split_tender_charge_params[:currency])
+
+      raise Lightrail::LightrailArgumentError.new("Must provide a payment method for either Lightrail or Stripe: #{split_tender_charge_params.inspect}") unless (self.has_lightrail_payment_option?(split_tender_charge_params) || self.has_stripe_payment_option?(split_tender_charge_params))
+
+      return true
     end
 
     def self.has_stripe_payment_option?(charge_params)

--- a/lib/lightrail_stripe/split_tender_validator.rb
+++ b/lib/lightrail_stripe/split_tender_validator.rb
@@ -1,10 +1,11 @@
 module Lightrail
   class SplitTenderValidator < Lightrail::Validator
 
-    def self.validate_split_tender_charge_params! (split_tender_charge_params)
+    def self.validate_split_tender_charge_params! (split_tender_charge_params, lr_share=0)
       begin
         return true if ((split_tender_charge_params.is_a? Hash) &&
             Lightrail::Validator.validate_amount!(split_tender_charge_params[:amount]) &&
+            (split_tender_charge_params[:amount] >= lr_share) &&
             Lightrail::Validator.validate_currency!(split_tender_charge_params[:currency]) &&
             (self.has_lightrail_payment_option?(split_tender_charge_params) ||
                 self.has_stripe_payment_option?(split_tender_charge_params)))

--- a/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
+++ b/lib/lightrail_stripe/stripe_lightrail_split_tender_charge.rb
@@ -4,7 +4,7 @@ module Lightrail
 
     def self.create (charge_params, lr_share)
       # Convert to Translator.translate_split_tender_charge_params!()
-      Lightrail::SplitTenderValidator.validate_split_tender_charge_params!(charge_params)
+      Lightrail::SplitTenderValidator.validate_split_tender_charge_params!(charge_params, lr_share)
 
       total_amount = charge_params[:amount]
       currency = charge_params[:currency]
@@ -55,7 +55,7 @@ module Lightrail
     end
 
     def self.simulate (charge_params, lr_share)
-      Lightrail::SplitTenderValidator.validate_split_tender_charge_params!(charge_params)
+      Lightrail::SplitTenderValidator.validate_split_tender_charge_params!(charge_params, lr_share)
 
       total_amount = charge_params[:amount]
       currency = charge_params[:currency]

--- a/lib/lightrail_stripe/version.rb
+++ b/lib/lightrail_stripe/version.rb
@@ -1,3 +1,3 @@
 module LightrailStripe
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/stripe_lightrail_split_tender_charge_spec.rb
+++ b/spec/stripe_lightrail_split_tender_charge_spec.rb
@@ -185,6 +185,11 @@ RSpec.describe Lightrail::StripeLightrailSplitTenderCharge do
         charge_params.delete(:source)
         expect {split_tender_charge.create(charge_params, 0)}.to raise_error(Lightrail::LightrailArgumentError)
       end
+
+      it "throws an error when Lightrail share set to more than total split tender amount" do
+        expect {split_tender_charge.create(charge_params, 10000000)}.to raise_error(Lightrail::LightrailArgumentError)
+      end
+
     end
   end
 


### PR DESCRIPTION
Covers an edge case where the number passed in for Lightrail's share of the transaction could be greater than the total amount set in the split tender params. Previously, the method would post the charge to Lightrail with the specified Lightrail amount without checking that it made sense wrt the total.

Passing in the Lightrail share to the validator is made optional so that it can still be used in the methods that create/simulate a charge and calculate the split automatically; these methods need to validate the other parameters before they know what the Lightrail amount should be.